### PR TITLE
Snowplow extension 1.0.2

### DIFF
--- a/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
+++ b/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
@@ -1,6 +1,6 @@
 {
   "linkers": {
-    "splinker": {
+    "sp_amp_linker": {
       "ids": {
         "_sp_duid": "${duid}",
         "amp_id": "${ampVistorId}"
@@ -10,16 +10,16 @@
   "cookies": {
     "enabled": true,
     "_sp_duid": {
-      "value": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(COOKIE(_sp_duid), COOKIE(_sp_duid), LINKER_PARAM(splinker,_sp_duid)))"
+      "value": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(COOKIE(_sp_duid), COOKIE(_sp_duid), LINKER_PARAM(sp_amp_linker,_sp_duid)))"
     },
     "_sp_ampid": {
-      "value": "$IF(COOKIE(_sp_id), COOKIE(_sp_id), LINKER_PARAM(splinker, amp_id))"
+      "value": "$IF(COOKIE(_sp_id), COOKIE(_sp_id), LINKER_PARAM(sp_amp_linker, amp_id))"
     }
   },
   "vars": {
     "trackerVersion": "amp-1.0.2",
     "ampVistorId": "CLIENT_ID(_sp_ampid)",
-    "duid": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(COOKIE(_sp_duid), COOKIE(_sp_duid), LINKER_PARAM(splinker,_sp_duid)))",
+    "duid": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(COOKIE(_sp_duid), COOKIE(_sp_duid), LINKER_PARAM(sp_amp_linker,_sp_duid)))",
     "nullString": "null",
     "customEventTemplate": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:${customEventSchemaVendor}/${customEventSchemaName}/jsonschema/${customEventSchemaVersion}\",\"data\":${customEventSchemaData}}}",
     "contextsHead": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0\",\"data\":[{\"schema\":\"iglu:dev.amp.snowplow/amp_id/jsonschema/1-0-0\",\"data\":{\"ampClientId\":\"${ampVistorId}\", \"domainUserid\": \"${duid}\", \"userId\": \"${userId}\"}},$REPLACE(`${customContexts}`, `^,*(.+?),*$`, `$1,`)",

--- a/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
+++ b/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
@@ -1,6 +1,6 @@
 {
   "linkers": {
-    "linker": {
+    "splinker": {
       "ids": {
         "_sp_duid": "${duid}",
         "amp_id": "${ampVistorId}"
@@ -10,16 +10,16 @@
   "cookies": {
     "enabled": true,
     "_sp_duid": {
-      "value": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(COOKIE(_sp_duid), COOKIE(_sp_duid), LINKER_PARAM(linker,_sp_duid)))"
+      "value": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(COOKIE(_sp_duid), COOKIE(_sp_duid), LINKER_PARAM(splinker,_sp_duid)))"
     },
     "_sp_id": {
-      "value": "LINKER_PARAM(linker, amp_id)"
+      "value": "LINKER_PARAM(splinker, amp_id)"
     }
   },
   "vars": {
     "trackerVersion": "amp-1.0.2",
     "ampVistorId": "CLIENT_ID(_sp_id)",
-    "duid": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(COOKIE(_sp_duid), COOKIE(_sp_duid), LINKER_PARAM(linker,_sp_duid)))",
+    "duid": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(COOKIE(_sp_duid), COOKIE(_sp_duid), LINKER_PARAM(splinker,_sp_duid)))",
     "nullString": "null",
     "customEventTemplate": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:${customEventSchemaVendor}/${customEventSchemaName}/jsonschema/${customEventSchemaVersion}\",\"data\":${customEventSchemaData}}}",
     "contextsHead": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0\",\"data\":[{\"schema\":\"iglu:dev.amp.snowplow/amp_id/jsonschema/1-0-0\",\"data\":{\"ampClientId\":\"${ampVistorId}\", \"domainUserid\": \"${duid}\", \"userId\": \"${userId}\"}},$REPLACE(`${customContexts}`, `^,*(.+?),*$`, `$1,`)",

--- a/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
+++ b/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
@@ -13,7 +13,7 @@
       "value": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(LINKER_PARAM(sp_amp_linker,_sp_duid), LINKER_PARAM(sp_amp_linker,_sp_duid), COOKIE(_sp_duid)))"
     },
     "_sp_ampid": {
-      "value": "$IF(COOKIE(_sp_id), COOKIE(_sp_id), LINKER_PARAM(sp_amp_linker, amp_id))"
+      "value": "$IF(COOKIE(_sp_ampid), LINKER_PARAM(sp_amp_linker, amp_id), COOKIE(_sp_id))"
     }
   },
   "vars": {

--- a/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
+++ b/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
@@ -12,13 +12,13 @@
     "_sp_duid": {
       "value": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(COOKIE(_sp_duid), COOKIE(_sp_duid), LINKER_PARAM(splinker,_sp_duid)))"
     },
-    "_sp_id": {
-      "value": "LINKER_PARAM(splinker, amp_id)"
+    "_sp_ampid": {
+      "value": "$IF(COOKIE(_sp_id), COOKIE(_sp_id), LINKER_PARAM(splinker, amp_id))"
     }
   },
   "vars": {
     "trackerVersion": "amp-1.0.2",
-    "ampVistorId": "CLIENT_ID(_sp_id)",
+    "ampVistorId": "CLIENT_ID(_sp_ampid)",
     "duid": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(COOKIE(_sp_duid), COOKIE(_sp_duid), LINKER_PARAM(splinker,_sp_duid)))",
     "nullString": "null",
     "customEventTemplate": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:${customEventSchemaVendor}/${customEventSchemaName}/jsonschema/${customEventSchemaVersion}\",\"data\":${customEventSchemaData}}}",

--- a/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
+++ b/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
@@ -10,7 +10,7 @@
   "cookies": {
     "enabled": true,
     "_sp_duid": {
-      "value": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(COOKIE(_sp_duid), COOKIE(_sp_duid), LINKER_PARAM(sp_amp_linker,_sp_duid)))"
+      "value": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(LINKER_PARAM(sp_amp_linker,_sp_duid), LINKER_PARAM(sp_amp_linker,_sp_duid), COOKIE(_sp_duid)))"
     },
     "_sp_ampid": {
       "value": "$IF(COOKIE(_sp_id), COOKIE(_sp_id), LINKER_PARAM(sp_amp_linker, amp_id))"
@@ -19,7 +19,7 @@
   "vars": {
     "trackerVersion": "amp-1.0.2",
     "ampVistorId": "CLIENT_ID(_sp_ampid)",
-    "duid": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(COOKIE(_sp_duid), COOKIE(_sp_duid), LINKER_PARAM(sp_amp_linker,_sp_duid)))",
+    "duid": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(LINKER_PARAM(sp_amp_linker,_sp_duid), LINKER_PARAM(sp_amp_linker,_sp_duid), COOKIE(_sp_duid)))",
     "nullString": "null",
     "customEventTemplate": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:${customEventSchemaVendor}/${customEventSchemaName}/jsonschema/${customEventSchemaVersion}\",\"data\":${customEventSchemaData}}}",
     "contextsHead": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0\",\"data\":[{\"schema\":\"iglu:dev.amp.snowplow/amp_id/jsonschema/1-0-0\",\"data\":{\"ampClientId\":\"${ampVistorId}\", \"domainUserid\": \"${duid}\", \"userId\": \"${userId}\"}},$REPLACE(`${customContexts}`, `^,*(.+?),*$`, `$1,`)",

--- a/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
+++ b/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
@@ -17,7 +17,7 @@
     }
   },
   "vars": {
-    "aaVersion": "amp-1.0.2",
+    "trackerVersion": "amp-1.0.2",
     "ampVistorId": "CLIENT_ID(_sp_id)",
     "duid": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(COOKIE(_sp_duid), COOKIE(_sp_duid), LINKER_PARAM(linker,_sp_duid)))",
     "nullString": "null",
@@ -27,7 +27,7 @@
     "ampPagePingTemplate": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:dev.amp.snowplow/amp_page_ping/jsonschema/1-0-0\",\"data\":{\"scrollLeft\":${scrollLeft},\"scrollWidth\":${scrollWidth},\"viewportWidth\":${viewportWidth},\"scrollTop\":${scrollTop},\"scrollHeight\":${scrollHeight},\"viewportHeight\":${viewportHeight},\"totalEngagedTime\":${totalEngagedTime}}}}"
   },
   "requests": {
-    "basePrefix": "https://${collectorHost}/i?p=web&tv=${aaVersion}",
+    "basePrefix": "https://${collectorHost}/i?p=web&tv=${trackerVersion}",
     "pageView": "${basePrefix}&e=pv",
     "structEvent": "${basePrefix}&e=se&se_ca=${structEventCategory}&se_ac=${structEventAction}&se_la=${structEventLabel}&se_pr=${structEventProperty}&se_va=$IF(${structEventValue}, ${structEventValue}, ${nullString})",
     "pagePing": "${basePrefix}&e=pp&pp_mix=${scrollLeft}&pp_miy=${scrollTop}",

--- a/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
+++ b/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
@@ -13,7 +13,7 @@
       "value": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(LINKER_PARAM(sp_amp_linker,_sp_duid), LINKER_PARAM(sp_amp_linker,_sp_duid), COOKIE(_sp_duid)))"
     },
     "_sp_ampid": {
-      "value": "$IF(COOKIE(_sp_ampid), LINKER_PARAM(sp_amp_linker, amp_id), COOKIE(_sp_id))"
+      "value": "$IF(COOKIE(_sp_ampid), LINKER_PARAM(sp_amp_linker, amp_id), $IF(LINKER_PARAM(sp_amp_linker, amp_id), LINKER_PARAM(sp_amp_linker, amp_id), COOKIE(_sp_id)))"
     }
   },
   "vars": {

--- a/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
+++ b/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
@@ -10,18 +10,19 @@
   "cookies": {
     "enabled": true,
     "_sp_duid": {
-      "value": "$IF($IF(COOKIE(_sp_duid), COOKIE(_sp_duid), LINKER_PARAM(linker,_sp_duid)), $IF(COOKIE(_sp_duid), COOKIE(_sp_duid), LINKER_PARAM(linker,_sp_duid)), $SUBSTR(QUERY_PARAM(_sp),0,36))"
+      "value": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(COOKIE(_sp_duid), COOKIE(_sp_duid), LINKER_PARAM(linker,_sp_duid)))"
     },
     "_sp_id": {
       "value": "LINKER_PARAM(linker, amp_id)"
     }
   },
   "vars": {
-    "aaVersion": "amp-1.0.1",
+    "aaVersion": "amp-1.0.2",
     "ampVistorId": "CLIENT_ID(_sp_id)",
+    "duid": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(COOKIE(_sp_duid), COOKIE(_sp_duid), LINKER_PARAM(linker,_sp_duid)))",
     "nullString": "null",
     "customEventTemplate": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:${customEventSchemaVendor}/${customEventSchemaName}/jsonschema/${customEventSchemaVersion}\",\"data\":${customEventSchemaData}}}",
-    "contextsHead": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0\",\"data\":[{\"schema\":\"iglu:dev.amp.snowplow/amp_id/jsonschema/1-0-0\",\"data\":{\"ampClientId\":\"${ampVistorId}\", \"domainUserid\": \"COOKIE(_sp_duid)\", \"userId\": \"${userId}\"}},$REPLACE(`${customContexts}`, `^,*(.+?),*$`, `$1,`)",
+    "contextsHead": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0\",\"data\":[{\"schema\":\"iglu:dev.amp.snowplow/amp_id/jsonschema/1-0-0\",\"data\":{\"ampClientId\":\"${ampVistorId}\", \"domainUserid\": \"${duid}\", \"userId\": \"${userId}\"}},$REPLACE(`${customContexts}`, `^,*(.+?),*$`, `$1,`)",
     "contextsTail": "{\"schema\":\"iglu:dev.amp.snowplow/amp_web_page/jsonschema/1-0-0\",\"data\":{\"ampPageViewId\":\"PAGE_VIEW_ID_64\"}}]}",
     "ampPagePingTemplate": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:dev.amp.snowplow/amp_page_ping/jsonschema/1-0-0\",\"data\":{\"scrollLeft\":${scrollLeft},\"scrollWidth\":${scrollWidth},\"viewportWidth\":${viewportWidth},\"scrollTop\":${scrollTop},\"scrollHeight\":${scrollHeight},\"viewportHeight\":${viewportHeight},\"totalEngagedTime\":${totalEngagedTime}}}}"
   },

--- a/extensions/amp-analytics/analytics-vendors-list.md
+++ b/extensions/amp-analytics/analytics-vendors-list.md
@@ -464,7 +464,7 @@ Adds support for SimpleReach. Configuration details can be found at `http://docs
 
 Type attribute value: `snowplow`, `snowplow_v2`
 
-Adds support for Snowplow Analytics. More details for adding Snowplow Analytics support can be found at [github.com/snowplow/snowplow/wiki](https://github.com/snowplow/snowplow/wiki/Google-AMP-Tracker).
+Adds support for Snowplow Analytics. More details for adding Snowplow Analytics support can be found at [docs.snowplowanalytics.com](https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/google-amp-tracker/).
 
 ### Tail
 


### PR DESCRIPTION
Minor changes to the Snowplow Analytics amp-analytics extension.

Changes:

- Fix bug where duid is not sent from pages on the AMP CDN

This was because we attempted to set a cookie and then retrieve the value from that cookie.

Fixed by prioritising the value from the querystring ahead of the cookie.

- Rename _sp_id cookie

This was a poor naming choice as it's the same cookie name that a separate tracker uses, but a different ID. Very small chance of a conflict.

We avoid changing all AMP ID values, setting the new cookie to the value of the (old) _sp_id cookie when it's not found elsehwere.  We can remove this part in a subsequent release to simplify things.

- Rename 'linker' to 'sp_amp_linker'

Another poor naming choice - using the default opens the door for conflicts. Ripping off the plaster now while we're at it.

- Rename aaVersion to trackerVersion

Just a nitpick.
