### PR TITLE
[snowplow-analytics] ✨ Add optional consent context

### DIFF
--- a/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
+++ b/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
@@ -21,11 +21,12 @@
     "ampVistorId": "CLIENT_ID(_sp_ampid)",
     "duid": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(LINKER_PARAM(sp_amp_linker,_sp_duid), LINKER_PARAM(sp_amp_linker,_sp_duid), COOKIE(_sp_duid)))",
     "nullString": "null",
+    "consentContext": "{\"schema\":\"iglu:dev.amp.snowplow/amp_consent/jsonschema/1-0-0\",\"data\":{\"consentState\":\"${consentState}\",\"gdprApplies\": $IF($CONSENT_METADATA(gdprApplies), true, false),\"consentType\": \"$CONSENT_METADATA(consentStringType)\",\"purposeOne\":$IF($CONSENT_METADATA(purposeOne), true, false)}}",
     "customEventTemplate": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:${customEventSchemaVendor}/${customEventSchemaName}/jsonschema/${customEventSchemaVersion}\",\"data\":${customEventSchemaData}}}",
     "sessionContext": "{\"schema\":\"iglu:dev.amp.snowplow/amp_session/jsonschema/1-0-0\",\"data\":{\"ampSessionId\":${sessionId},\"ampSessionIndex\":${sessionCount},\"sessionEngaged\":$IF(${sessionEngaged}, true, false),\"sessionCreationTimestamp\":${sessionTimestamp}$IF(${sessionEventTimestamp},`,\"lastSessionEventTimestamp\":${sessionEventTimestamp}`)}}",
     "idContext": "{\"schema\":\"iglu:dev.amp.snowplow/amp_id/jsonschema/1-0-0\",\"data\":{\"ampClientId\":\"${ampVistorId}\",\"domainUserid\":\"${duid}\",\"userId\":\"${userId}\"}}",
     "webPageContext": "{\"schema\":\"iglu:dev.amp.snowplow/amp_web_page/jsonschema/1-0-0\",\"data\":{\"ampPageViewId\":\"PAGE_VIEW_ID_64\"}}",
-    "contextsHead": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0\",\"data\":[${idContext},${sessionContext},$REPLACE(`${customContexts}`, `^,*(.+?),*$`, `$1,`)",
+    "contextsHead": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0\",\"data\":[${idContext},${sessionContext}$IF(${trackConsent},`,${consentContext}`),$REPLACE(`${customContexts}`, `^,*(.+?),*$`, `$1,`)",
     "contextsTail": "${webPageContext}]}",
     "ampPagePingTemplate": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:dev.amp.snowplow/amp_page_ping/jsonschema/1-0-0\",\"data\":{\"scrollLeft\":${scrollLeft},\"scrollWidth\":${scrollWidth},\"viewportWidth\":${viewportWidth},\"scrollTop\":${scrollTop},\"scrollHeight\":${scrollHeight},\"viewportHeight\":${viewportHeight},\"totalEngagedTime\":${totalEngagedTime}}}}"
   },


### PR DESCRIPTION
### Description

Add a new schema describing the AMP consent state and the values we can track.

These data can come from the usage of the <amp-consent> capability for an integration with a CMP (Consent Management Platform). Based on the settings on the CMP and the user selections, the values in the fields shown in the schema are updated and are available for us to collect. 

Fields will be described in the schema.
- consentState
- gdprApplies
- consentType
- consentOne

closes #17 

Pending schema https://github.com/snowplow/iglu-central/pull/1329